### PR TITLE
json.load: drop encoding argument

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,7 @@ class JsonTester(testcase.FileBasedTesting):
             shutil.copy(regened_exp_loc, expected_loc)
 
         with open(expected_loc, 'rb') as ex:
-            expected = json.load(ex, encoding='utf-8')
+            expected = json.load(ex)
         if sort:
             assert sorted(expected) == sorted(results)
         else:


### PR DESCRIPTION
It was deprecated in Python 3.1 and removed in Python 3.9.
fixes https://github.com/nexB/debian-inspector/issues/14
cc @cole-h