### PR TITLE
Rename licence field to license in from_fields #25

### DIFF
--- a/src/debian_inspector/deb822.py
+++ b/src/debian_inspector/deb822.py
@@ -73,8 +73,8 @@ def get_paragraphs_as_field_groups_from_lines(numbered_lines):
         if line.is_blank():
             # peek one line ahead if next is a header field...
             if (
-                current_field 
-                and idx != last_idx 
+                current_field
+                and idx != last_idx
                 and not numbered_lines[idx + 1].is_field_declaration()
                 and not numbered_lines[idx + 1].is_blank()
             ):
@@ -267,6 +267,13 @@ class Deb822Field:
         name = name.strip().lower()
         if not name:
             return
+
+        # There are some cases where Debian copyright files spells the
+        # license field of a paragraph as "licence". We must correct this
+        # otherwise the license information will be stored under "licence"
+        # instead of "license".
+        if name == 'licence':
+            name = 'license'
 
         value = value.strip()
         first_line = NumberedLine(number=line.number, value=value)

--- a/tests/data/copyright/test-licence-license.copyright
+++ b/tests/data/copyright/test-licence-license.copyright
@@ -1,0 +1,4 @@
+Files: ext/xmlrpc/libxmlrpc/base64.h ext/xmlrpc/libxmlrpc/base64.c
+Copyright: John Walker
+Licence: public-domain
+ This program is in the public domain.

--- a/tests/data/copyright/test-licence-license.copyright-expected-DebianCopyright.json
+++ b/tests/data/copyright/test-licence-license.copyright-expected-DebianCopyright.json
@@ -1,0 +1,24 @@
+{
+  "paragraphs": [
+    {
+      "files": "ext/xmlrpc/libxmlrpc/base64.h\n ext/xmlrpc/libxmlrpc/base64.c",
+      "copyright": "John Walker",
+      "license": "public-domain\n This program is in the public domain.",
+      "comment": "",
+      "line_numbers_by_field": {
+        "files": [
+          1,
+          1
+        ],
+        "copyright": [
+          2,
+          2
+        ],
+        "license": [
+          3,
+          4
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -119,6 +119,13 @@ class TestDebianCopyright(JsonTester):
         results = copyright.DebianCopyright.from_file(test_file)
         self.check_json(results.to_dict(with_lines=True), expected_loc, regen=False)
 
+    def test_DebianCopyright_from_file_licence_to_license(self):
+        test_file = self.get_test_loc('copyright/test-licence-license.copyright')
+        expected_loc = 'copyright/test-licence-license.copyright-expected-DebianCopyright.json'
+        results = copyright.DebianCopyright.from_file(test_file)
+        self.check_json(results.to_dict(with_lines=True), expected_loc, regen=True)
+
+
 
 class TestCopyright(JsonTester):
     test_data_dir = path.join(path.dirname(__file__), 'data')


### PR DESCRIPTION
When a field name of `licence` is encountered in `from_fields()`, rename the field to `license` before storing the license info to that field.